### PR TITLE
Replace pip_install with pip_parse

### DIFF
--- a/sphinx/indirect_repositories.bzl
+++ b/sphinx/indirect_repositories.bzl
@@ -1,7 +1,7 @@
-load("@rules_python//python:pip.bzl", "pip_install")
+load("@rules_python//python:pip.bzl", "pip_parse")
 
 def rules_sphinx_indirect_deps():
-    pip_install(
+    pip_parse(
         name = "pip_deps",
-        requirements = "@rules_sphinx//sphinx/tools:requirements.txt",
+        requirements_lock = "@rules_sphinx//sphinx/tools:requirements.txt",
     )


### PR DESCRIPTION
From
https://github.com/bazelbuild/rules_python/blob/ee2cc930e33db358c469f3bd53bc3112de8045a2/CHANGELOG.md#user-content-changed-1

>Breaking changes:
(pip) pip_install repository rule in this release has been disabled and will fail by default. The API symbol is going to be removed in the next version, please migrate to pip_parse as a replacement. The pip_parse rule no longer supports requirements attribute, please use requirements_lock instead.